### PR TITLE
Allow and Ignore Non-semver tags

### DIFF
--- a/init.go
+++ b/init.go
@@ -3,6 +3,7 @@ package chglog
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
@@ -34,7 +35,8 @@ func InitChangelog(gitRepo *git.Repository, owner string, notes *ChangeLogNotes,
 		tagName := t.Name().Short()
 
 		if version, err = semver.NewVersion(tagName); err != nil || version == nil {
-			return fmt.Errorf("unable to parse version from tag: %s : %w", tagName, err)
+			fmt.Fprintf(os.Stderr, "Warning: unable to parse version from tag: %s : %v\n", tagName, err)
+			return nil
 		}
 
 		tags = append(tags, version)

--- a/order_test.go
+++ b/order_test.go
@@ -2,6 +2,8 @@ package chglog
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"testing"
 	"time"
 
@@ -11,8 +13,68 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/smartystreets/goconvey/convey"
+	. "github.com/smartystreets/goconvey/convey"
 )
+
+type testRepo struct {
+	Git    *git.Repository
+	Source *git.Worktree
+	seqno  int
+}
+
+func newTestRepo() *testRepo {
+	var (
+		repo *git.Repository
+		tree *git.Worktree
+		err  error
+	)
+
+	fs := memfs.New()
+
+	if repo, err = git.Init(memory.NewStorage(), fs); err != nil {
+		log.Fatal(err)
+	}
+
+	if tree, err = repo.Worktree(); err != nil {
+		log.Fatal(err)
+	}
+
+	return &testRepo{
+		Git:    repo,
+		Source: tree,
+	}
+}
+
+// modifyAndCommit creates the file if it does not exist, appends a
+// change, commits the file, and returns the hash of the commit.
+func (r *testRepo) modifyAndCommit(filename string, opts *git.CommitOptions) plumbing.Hash {
+	var (
+		hash plumbing.Hash
+		err  error
+		file billy.File
+	)
+
+	if file, err = r.Source.Filesystem.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	if _, err = file.Write([]byte(fmt.Sprintf("commit %d\n", r.seqno))); err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err = r.Source.Add(filename); err != nil {
+		log.Fatal(err)
+	}
+
+	if hash, err = r.Source.Commit(fmt.Sprintf("commit %d", r.seqno), opts); err != nil {
+		log.Fatal(err)
+	}
+
+	r.seqno++
+
+	return hash
+}
 
 func defSignature() *object.Signature {
 	tm, err := time.Parse(time.RFC3339, "2000-01-01T12:00:00+07:00")
@@ -34,64 +96,66 @@ func defCommitOptions() *git.CommitOptions {
 	}
 }
 
-func newTestRepo() (*git.Repository, error) {
-	fs := memfs.New()
-
-	return git.Init(memory.NewStorage(), fs)
-}
-
 func TestOrderChangelog(t *testing.T) {
-	var (
-		gitRepo *git.Repository
-		gitTree *git.Worktree
-		file    billy.File
-		testCLE ChangeLogEntries
-	)
-
-	goldcle, err := Parse("./testdata/gold-order-changelog.yml")
+	goldCLE, err := Parse("./testdata/gold-order-changelog.yml")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if gitRepo, err = newTestRepo(); err != nil {
-		t.Fatal(err)
-	}
-
-	if gitTree, err = gitRepo.Worktree(); err != nil {
-		t.Fatal(err)
-	}
-
-	if file, err = gitTree.Filesystem.Create("file"); err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
+	repo := newTestRepo()
 
 	for i := 0; i <= 10; i++ {
-		var hash plumbing.Hash
+		hash := repo.modifyAndCommit("file", defCommitOptions())
 
-		if _, err = file.Write([]byte(fmt.Sprintf("commit %d\n", i))); err != nil {
+		if _, err = repo.Git.CreateTag(fmt.Sprintf("v0.%d.0", i), hash, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCLE, err := InitChangelog(repo.Git, "", nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	Convey("Generated entry should be the same as the golden entry", t, func() {
+		So(testCLE, ShouldResemble, goldCLE)
+	})
+
+}
+
+func TestSemverTag(t *testing.T) {
+	repo := newTestRepo()
+	tag := "1.0.0"
+
+	Convey("Semver tags should be parsed", t, func() {
+		hash := repo.modifyAndCommit("file", defCommitOptions())
+
+		if _, err := repo.Git.CreateTag(tag, hash, nil); err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err = gitTree.Add("file"); err != nil {
-			t.Fatal()
+		cle, err := InitChangelog(repo.Git, "", nil, nil, false)
+		if err != nil {
+			t.Fatal(err)
 		}
 
-		if hash, err = gitTree.Commit(fmt.Sprintf("commit %d", i), defCommitOptions()); err != nil {
-			t.Fatal()
-		}
-
-		if _, err = gitRepo.CreateTag(fmt.Sprintf("v0.%d.0", i), hash, nil); err != nil {
-			t.Fatal()
-		}
-	}
-
-	if testCLE, err = InitChangelog(gitRepo, "", nil, nil, false); err != nil {
-		t.Fatal(err)
-	}
-
-	convey.Convey("Generated entry should be the same as the golden entry", t, func() {
-		convey.So(testCLE, convey.ShouldResemble, goldcle)
+		So(cle, ShouldHaveLength, 1)
+		So(cle[0].Semver, ShouldEqual, tag)
 	})
 
+	Convey("Not Semver tags should be ignored", t, func() {
+		hash := repo.modifyAndCommit("file", defCommitOptions())
+
+		if _, err := repo.Git.CreateTag("text", hash, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		cle, err := InitChangelog(repo.Git, "", nil, nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		So(cle, ShouldHaveLength, 1)
+		So(cle[0].Semver, ShouldEqual, tag)
+	})
 }


### PR DESCRIPTION
#76 

This is broken up into two commits. The first just converts the error to a warning, and writes to stderr. The second adds a test, but also reworks the `order_test.go` code from my previous PR to add a `testRepo` to reduce some test boiler plate.

Please let me know what you think, both about the behavior change and how best to address it.

