### PR TITLE
fix: do not call function on null cmd parent

### DIFF
--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -75,10 +75,6 @@ func AddCmd(config *viper.Viper) (cmd *cobra.Command) {
 		"",
 		"Footer note for this entry")
 
-	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(c, args)
-	}
-
 	cmd.RunE = func(c *cobra.Command, args []string) (err error) {
 		var (
 			repoPath string

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -23,9 +23,6 @@ func ConfigCmd(config *viper.Viper) (cmd *cobra.Command) {
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return config.BindPFlag("package-name", cmd.Flags().Lookup("package-name"))
 	}
-	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(c, args)
-	}
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {
 		// Filter some config settings

--- a/pkg/commands/format.go
+++ b/pkg/commands/format.go
@@ -61,9 +61,6 @@ func FormatCmd(config *viper.Viper) (cmd *cobra.Command) {
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return config.BindPFlag("package-name", cmd.Flags().Lookup("package-name"))
 	}
-	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(c, args)
-	}
 
 	cmd.RunE = func(c *cobra.Command, args []string) (err error) {
 		var (

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -12,9 +12,6 @@ func VersionCmd(config *viper.Viper) (cmd *cobra.Command) {
 		Use:   "version",
 		Short: "display version info",
 	}
-	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
-		cmd.Parent().PersistentPreRun(c, args)
-	}
 	cmd.Run = func(c *cobra.Command, args []string) {
 		version := fmt.Sprintf("%s %s", config.GetString("app.name"), config.GetString("app.version"))
 		if config.GetBool("debug") {


### PR DESCRIPTION
With the version v0.4.1, I was still able to reproduce the panic for the different commands `config`, `version`, `add`, `format`.

For instance:

```bash
$ ~/chglog_0.4.1_Darwin_x86_64/chglog version
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1531890]

goroutine 1 [running]:
github.com/goreleaser/chglog/pkg/commands.VersionCmd.func1(0xc00021a900?, {0x1ac17c0?, 0x0?, 0x0?})
	github.com/goreleaser/chglog@v0.4.1/pkg/commands/version.go:16 +0x30
github.com/spf13/cobra.(*Command).execute(0xc00021a900, {0x1ac17c0, 0x0, 0x0})
	github.com/spf13/cobra@v1.6.1/command.go:896 +0x711
github.com/spf13/cobra.(*Command).ExecuteC(0xc00021a000)
	github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
	github.com/goreleaser/chglog@v0.4.1/cmd/chglog/main.go:56 +0x35c
```

Closes #119

PS: I'm not sure how to add tests to avoid this again so I did not add them. Nevertheless if you have an idea I'll be glad to add them though.