### PR TITLE
fix: lint errors

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -42,19 +42,23 @@ func TestFormatChangelog(t *testing.T) {
 
 func accept(t *testing.T, tmplData string, pkg PackageChangeLog) {
 	t.Helper()
-	if tpl, err := LoadTemplateData(tmplData); err != nil {
+
+	tpl, err := LoadTemplateData(tmplData)
+	if err != nil {
 		t.Error(err)
 
 		return
-	} else if testdata, err := FormatChangelog(&pkg, tpl); err != nil {
+	}
+
+	testdata, err := FormatChangelog(&pkg, tpl)
+	if err != nil {
 		t.Error(err)
 
 		return
-	} else {
-		golddata, _ := os.ReadFile(fmt.Sprintf("./testdata/%s", pkg.Name))
+	}
 
-		if diff := cmp.Diff(string(golddata), testdata); diff != "" {
-			t.Errorf("FormatChangelog mismatch (+got -want):\n%s", diff)
-		}
+	golddata, _ := os.ReadFile(fmt.Sprintf("./testdata/%s", pkg.Name))
+	if diff := cmp.Diff(string(golddata), testdata); diff != "" {
+		t.Errorf("FormatChangelog mismatch (+got -want):\n%s", diff)
 	}
 }

--- a/order_test.go
+++ b/order_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/smartystreets/goconvey/convey"
 )
 
 type testRepo struct {
@@ -118,8 +118,8 @@ func TestOrderChangelog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Convey("Generated entry should be the same as the golden entry", t, func() {
-		So(testCLE, ShouldResemble, goldCLE)
+	convey.Convey("Generated entry should be the same as the golden entry", t, func() {
+		convey.So(testCLE, convey.ShouldResemble, goldCLE)
 	})
 }
 
@@ -209,8 +209,8 @@ func TestOffBranchTags(t *testing.T) {
 		}
 	}
 
-	Convey("Generated entry should be the same as the golden entry", t, func() {
-		So(testCLE, ShouldResemble, goldCLE)
+	convey.Convey("Generated entry should be the same as the golden entry", t, func() {
+		convey.So(testCLE, convey.ShouldResemble, goldCLE)
 	})
 }
 
@@ -218,7 +218,7 @@ func TestSemverTag(t *testing.T) {
 	repo := newTestRepo()
 	tag := "1.0.0"
 
-	Convey("Semver tags should be parsed", t, func() {
+	convey.Convey("Semver tags should be parsed", t, func() {
 		hash := repo.modifyAndCommit(defCommitOptions())
 
 		if _, err := repo.Git.CreateTag(tag, hash, nil); err != nil {
@@ -230,11 +230,11 @@ func TestSemverTag(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		So(cle, ShouldHaveLength, 1)
-		So(cle[0].Semver, ShouldEqual, tag)
+		convey.So(cle, convey.ShouldHaveLength, 1)
+		convey.So(cle[0].Semver, convey.ShouldEqual, tag)
 	})
 
-	Convey("Not Semver tags should be ignored", t, func() {
+	convey.Convey("Not Semver tags should be ignored", t, func() {
 		hash := repo.modifyAndCommit(defCommitOptions())
 
 		if _, err := repo.Git.CreateTag("text", hash, nil); err != nil {
@@ -246,7 +246,7 @@ func TestSemverTag(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		So(cle, ShouldHaveLength, 1)
-		So(cle[0].Semver, ShouldEqual, tag)
+		convey.So(cle, convey.ShouldHaveLength, 1)
+		convey.So(cle[0].Semver, convey.ShouldEqual, tag)
 	})
 }


### PR DESCRIPTION
golangci-lint detected a few issues:
```
format_test.go:53:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
	} else {
		golddata, _ := os.ReadFile(fmt.Sprintf("./testdata/%s", pkg.Name))

		if diff := cmp.Diff(string(golddata), testdata); diff != "" {
			t.Errorf("FormatChangelog mismatch (+got -want):\n%s", diff)
		}
	}
order_test.go:16:2: dot-imports: should not use dot imports (revive)
	. "github.com/smartystreets/goconvey/convey"
	^
```