### PR TITLE
fix: time formatting for deb changelog

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -26,7 +26,7 @@ const (
    - {{$n}}{{end}}
 {{- end}}{{end}}
 
- -- {{ .Packager }}  {{ date_in_zone "Mon, 02 Jan 2006 03:04:05 -0700" .Date "UTC" }}
+ -- {{ .Packager }}  {{ date_in_zone "Mon, 02 Jan 2006 15:04:05 -0700" .Date "UTC" }}
 {{ end }}
 `
 	releaseTpl = `

--- a/testdata/TestFormatChangelog-deb
+++ b/testdata/TestFormatChangelog-deb
@@ -8,5 +8,5 @@ TestFormatChangelog-deb (0.0.1)
    - * This is a test repo
    - * so ya!
 
- -- Dj Gilcrease <d.gilcrease@f5.com>  Fri, 18 Oct 2019 11:05:33 +0000
+ -- Dj Gilcrease <d.gilcrease@f5.com>  Fri, 18 Oct 2019 23:05:33 +0000
 


### PR DESCRIPTION
The format string used when formatting changelogs for debs accidentally implied a 12-hour clock (e.g. 15:00 would produce 03:00) when it should be a 24-hour clock.

This is evidenced by the time in the test data incorrectly being 11:05 (11 am) when it should be 23:05 (11 pm).